### PR TITLE
rsyncd: new xinetd context with augeas 0.9.0

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,6 +2,8 @@ class rsyncd {
 
   realize(Package["rsync"])
 
+  include rsyncd::params
+
   file { "/etc/rsyncd.conf":
     ensure => present,
   }
@@ -29,7 +31,7 @@ class rsyncd {
 
     RedHat: {
       augeas { "enable rsync service":
-        context => "/files/etc/xinetd.d/rsync/rsync/",
+        context => $xinetdcontext,
         changes => [
           "set disable no",
           "set socket_type stream",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,13 @@
+class rsyncd::params {
+
+  $xinetdcontext = $operatingsystem ? {
+    'RedHat' => $lsbmajdistrelease ? {
+      6 =>  $lsbdistrelease ? {
+        /6\.0|6\.1/ => '/files/etc/xinetd.d/rsync/rsync/',
+        default   => '/files/etc/xinetd.d/rsync/service/',
+      },
+      default => '/files/etc/xinetd.d/rsync/rsync/',
+    },
+  }
+
+}


### PR DESCRIPTION
The same as two days ago, with factorization of the versions.
