### PR TITLE
Add prexferexec and postxferexec options to rsyncd::export

### DIFF
--- a/README
+++ b/README
@@ -40,5 +40,7 @@ Example usage:
     secrets => "/home/dba/rsyncd.secret",
     allow => "192.168.0.0/24",
     require => [File["/backup-mysql"], File["/home/dba/rsyncd.secret"]],
+    prexferexec => "/home/dba/bin/pre-exec.sh"
+    postxferexec => "/home/dba/bin/post-exec.sh"
   }
 

--- a/manifests/export.pp
+++ b/manifests/export.pp
@@ -10,6 +10,8 @@ define rsyncd::export (
   $secrets=undef,
   $allow=undef,
   $deny=undef,
+  $prexferexec=undef,
+  $postxferexec=undef,
 ) {
 
   $file = '/etc/rsyncd.conf'
@@ -102,6 +104,25 @@ define rsyncd::export (
             require => Augeas["setup rsyncd export ${name}"],
           }
         }
+
+        if $prexferexec {
+          augeas { "set pre-xfer exec for ${name}":
+            incl    => $file,
+            lens    => 'Rsyncd.lns',
+            changes => "set '${name}/pre-xfer\\ exec' ${prexferexec}",
+            require => Augeas["setup rsyncd export ${name}"],
+          }
+        }
+
+        if $postxferexec {
+          augeas { "set post-xfer exec for ${name}":
+            incl    => $file,
+            lens    => 'Rsyncd.lns',
+            changes => "set '${name}/post-xfer\\ exec' ${postxferexec}",
+            require => Augeas["setup rsyncd export ${name}"],
+          }
+        }
+
 
       }
       else {


### PR DESCRIPTION
Add support configuration options in rsyncd.conf:
  pre-xfer exec
  post-xfer exec

Updated README to demonstrate usage.
