### PR TITLE
Add new parameter incoming chmod

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,6 @@ rsyncd::export { "backup":
   require => [File["/backup-mysql"], File["/home/dba/rsyncd.secret"]],
   prexferexec => "/home/dba/bin/pre-exec.sh"
   postxferexec => "/home/dba/bin/post-exec.sh"
+  incomingchmod => "go=-w,+X"
 }
 ```

--- a/manifests/export.pp
+++ b/manifests/export.pp
@@ -12,6 +12,7 @@ define rsyncd::export (
   $deny=undef,
   $prexferexec=undef,
   $postxferexec=undef,
+  $incomingchmod=undef,
 ) {
 
   $file = '/etc/rsyncd.conf'
@@ -33,7 +34,7 @@ define rsyncd::export (
         }
 
         if $::osfamily == 'RedHat' {
-          case $::lsbmajdistrelease {
+          case $::operatingsystemmajrelease {
 
             '4','5','6': { }
 
@@ -120,6 +121,14 @@ define rsyncd::export (
           }
         }
 
+        if $incomingchmod {
+          augeas { "set incoming chmod for ${name}":
+            incl    => $file,
+            lens    => 'Rsyncd.lns',
+            changes => "set '${name}/incoming\\ chmod' ${incomingchmod}",
+            require => Augeas["setup rsyncd export ${name}"],
+          }
+        }
 
       }
       else {

--- a/spec/defines/export_spec.rb
+++ b/spec/defines/export_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe 'rsyncd::export' do
+  let(:title) { 'test-export' }
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:pre_condition) do
+        "
+        package { ['rsync', 'xinetd']: ensure => 'present' }
+        service { 'xinetd': ensure => 'running' }
+        include rsyncd
+        "
+      end
+
+      context 'with no parameters set' do
+        it { is_expected.to compile.and_raise_error(%r{missing mandatory \$path parameter for rsyncd::export}) }
+      end
+
+      context 'with defaults parameters' do
+        let(:params) { { 'path' => '/some/path' } }
+
+        it { is_expected.to compile }
+      end
+
+      context 'with values set for every parameter' do
+        let(:params) do
+          {
+            'ensure'   => 'present',
+            'chroot'   => false,
+            'readonly' => false,
+            'path'     => '/some/path',
+            'uid'      => 'user1',
+            'gid'      => 'group1',
+            'incomingchmod' => 'go-w,+X',
+          }
+        end
+
+        it { is_expected.to compile }
+        it {
+          is_expected.to contain_augeas("setup rsyncd export #{title}").with(
+            'changes' => [
+              "set '#{title}/#comment' 'created by rsyncd::export(#{title})'",
+              "set '#{title}/path' '/some/path'",
+              "set '#{title}/use\\ chroot' false",
+              "set '#{title}/read\\ only' false",
+            ],
+          )
+        }
+        it { is_expected.to contain_augeas("set rsyncd uid for #{title}").with_changes("set '#{title}/uid' user1") }
+        it { is_expected.to contain_augeas("set rsyncd gid for #{title}").with_changes("set '#{title}/gid' group1") }
+        it { is_expected.to contain_augeas("set incoming chmod for #{title}").with_changes("set '#{title}/incoming\\ chmod' go-w,+X") }
+      end
+
+      context 'with ensure absent' do
+        let(:params) { { 'ensure' => 'absent' } }
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_augeas("remove #{title}").with_changes("remove '#{title}'") }
+      end
+
+      context 'with unknown ensure' do
+        let(:params) { { 'ensure' => 'quirky' } }
+
+        it { is_expected.to compile.and_raise_error(%r{Unknown value for ensure: quirky}) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
For resources that are writeable it makes sense to be able to set some
permissions in incoming files and directories. Therefore support for the
incoming chmod parameter has been added.